### PR TITLE
Fix robe of protection giving MC2 and no effect from dragon scales

### DIFF
--- a/hackem_changelog.txt
+++ b/hackem_changelog.txt
@@ -15,6 +15,7 @@
 
 Version 1.1 (unreleased)
 
+Fix: Fix issue of robe of protection not giving effects of merged dragon scales and reduce to MC1 (reported by VaderFLAG).
 Fix: Cloning of wands of wishing/magic lamp/markers will yield other items.
 Fix: Allow cloning of invocation items
 Fix: Add second weapon attack for Und so they can two-weapon (reported by VaderFLAG).

--- a/src/objects.c
+++ b/src/objects.c
@@ -560,7 +560,7 @@ ARMOR("jacket", None,
 ARMOR("robe", "red robe",
       0, 0, 0, 0,           1, 1, 40, 25, 9, 0, ARM_SUIT, LEATHER, CLR_RED),
 ARMOR("robe of protection", "blue robe",                        /* Slash'EM */
-      0, 1, 0, PROTECTION,  1, 1, 40, 50, 5, 1, ARM_SUIT, LEATHER, CLR_BLUE),
+      0, 1, 0, 0,           1, 1, 40, 50, 5, 1, ARM_SUIT, LEATHER, CLR_BLUE),
 ARMOR("robe of power", "orange robe",                           /* Slash'EM */
       0, 1, 0, 0,           0, 1, 40, 50, 9, 0, ARM_SUIT, LEATHER, CLR_ORANGE),
 ARMOR("robe of weakness", "green robe",                         /* Slash'EM */


### PR DESCRIPTION
The PROTECTION flag was dropped and the can is set to 1 to give MC1. The bug happened in wear.c:134 when the result of the bitmask operation below set the u.uprops[ANTIMAGIC].extrinsic to 0.
u.uprops[p].extrinsic & ~wp->w_mask;
This also happened for other colors of dragon scales. This was reported by VaderFLAG.