### PR TITLE
Fix medical kits can now cure parasitic larva

### DIFF
--- a/hackem_changelog.txt
+++ b/hackem_changelog.txt
@@ -15,6 +15,7 @@
 
 Version 1.1 (unreleased)
 
+Fix: Medical kits can cure parasitic larva (reported by VaderFLAG).
 Fix: Fix issue of robe of protection not giving effects of merged dragon scales and reduce to MC1 (reported by VaderFLAG).
 Fix: Cloning of wands of wishing/magic lamp/markers will yield other items.
 Fix: Allow cloning of invocation items

--- a/src/apply.c
+++ b/src/apply.c
@@ -2417,7 +2417,10 @@ struct obj *obj;
             if (can_use) {
                 if (Sick)
                     make_sick(0L, (char *) 0, TRUE, SICK_ALL);
-                else if (Blinded > (long) (u.ucreamed + 1))
+                else if (LarvaCarrier) {
+                    You_feel("as if your body is your own again.");
+                    make_carrier(0L, FALSE);
+                } else if (Blinded > (long) (u.ucreamed + 1))
                     make_blinded(u.ucreamed ? (long) (u.ucreamed + 1) : 0L,
                                  TRUE);
                 else if (HHallucination)
@@ -2431,7 +2434,7 @@ struct obj *obj;
                 else if (u.uhp < u.uhpmax) {
                     u.uhp += rn1(10, 10);
                     if (u.uhp > u.uhpmax)
-                    u.uhp = u.uhpmax;
+                        u.uhp = u.uhpmax;
                     You_feel("better.");
                     context.botl = TRUE;
                 } else


### PR DESCRIPTION
Add the ability for medical kits to cure parasitic larva.
It has the second highest priority on curing after sickness.
Reported by VaderFLAG.