### PR TITLE
Reduce jedi jump Pw cost from 25 to 10

### DIFF
--- a/hackem_changelog.txt
+++ b/hackem_changelog.txt
@@ -1,4 +1,4 @@
-                           
+
 # Hack'EM Changelog
 
 ## Credits
@@ -15,6 +15,7 @@
 
 Version 1.1 (unreleased)
 
+Change the Pw cost of jedi jump #tech from 25 to 10 (like the spell).
 Fix: Medical kits can cure parasitic larva (reported by VaderFLAG).
 Fix: Fix issue of robe of protection not giving effects of merged dragon scales and reduce to MC1 (reported by VaderFLAG).
 Fix: Cloning of wands of wishing/magic lamp/markers will yield other items.

--- a/src/tech.c
+++ b/src/tech.c
@@ -3520,13 +3520,13 @@ int
 tech_jedijump(tech_no)
 int tech_no;
 {
-    if (u.uen < 25) {
-         You("can't channel the force around you. Jedi jumps require 25 points of mana!");
+    if (u.uen < 10) {
+         You("can't channel the force around you. Jedi jumps require 10 points of mana!");
          return 0;
     }
     if (!jump((techlev(tech_no) / 5) + 1))
          return 0;
-    u.uen -= 25;
+    u.uen -= 10;
     return 1;
 }
 


### PR DESCRIPTION
This would bring the cost in line with the spell jumping.