### PR TITLE
Fix buffer overflow in ^X for eaten monsters

### DIFF
--- a/hackem_changelog.txt
+++ b/hackem_changelog.txt
@@ -15,6 +15,7 @@
 
 Version 1.1 (unreleased)
 
+Fix: Fix buffer overflow in the ^X menu caused by eaten monsters when playing doppelgangers.
 Change the Pw cost of jedi jump #tech from 25 to 10 (like the spell).
 Fix: Medical kits can cure parasitic larva (reported by VaderFLAG).
 Fix: Fix issue of robe of protection not giving effects of merged dragon scales and reduce to MC1 (reported by VaderFLAG).

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -2272,15 +2272,29 @@ int final; /* ENL_GAMEINPROGRESS:0, ENL_GAMEOVERALIVE, ENL_GAMEOVERDEAD */
         enlght_out_attr(ATR_SUBHEAD, "Eaten Memory:");
         Strcat(buf, " ");
         /*you_have(buf, "Eaten memory of these monsters:");*/
+        char full = 0;
         for (int i = LOW_PM; i < NUMMONS; i++) {
             if (mvitals[i].eaten) {
                 /*Sprintf(buf, "%s, ", mons[i].mname);*/
+
+                // Check for mname + "..." + '\0'
+                if (BUFSZ < strlen(buf) + strlen(mons[i].mname) + 3 + 1) {
+                    full = 1;
+                    break;
+                }
                 strcat(buf, mons[i].mname);
                 Strcat(buf, ", ");
             }
         }
-        if (strlen(buf) > 3) {
-            buf[strlen(buf) - 2] = '\0';
+        size_t len_buf = strlen(buf);
+        if (len_buf > 3) {
+            if (full) {
+                // Replace ", " with "...\0"
+                buf[len_buf - 2] = buf[len_buf - 1] = buf[len_buf] = '.';
+                buf[len_buf + 1] = '\0';
+            } else {
+                buf[len_buf - 2] = '\0';
+            }
             enlght_out(buf);
         } else {
             enlght_out("None");


### PR DESCRIPTION
This changes the behaviour so that when buf is going to be overflowed when writing a new monster in the eaten list
instead finish the list with "...\0".