### PR TITLE
Set menu->reuse_accels if curletter is reused

### DIFF
--- a/hackem_changelog.txt
+++ b/hackem_changelog.txt
@@ -15,6 +15,7 @@
 
 Version 1.1 (unreleased)
 
+Fix: Reused glyphs in #wizlevelport in curses mode don't work (menu->reuse_accels does not get set).
 Fix: Fix the lightsaber prototype not giving reflection when wielded (reported by mobileuser).
 Fix: Fix buffer overflow in the ^X menu caused by eaten monsters when playing doppelgangers.
 Change the Pw cost of jedi jump #tech from 25 to 10 (like the spell).

--- a/win/curses/cursdial.c
+++ b/win/curses/cursdial.c
@@ -1135,11 +1135,15 @@ menu_display_page(nhmenu *menu, WINDOW * win, int page_num, char *selectors)
         if (menu_item_ptr->identifier.a_void != NULL) {
             if (menu_item_ptr->accelerator != 0) {
                 curletter = menu_item_ptr->accelerator;
+
+                if (curletter >= 'a' && page_num > 1) {
+                    menu->reuse_accels = TRUE;
+                }
             } else {
                 if (first_accel) {
                     curletter = menu_get_accel(TRUE);
                     first_accel = FALSE;
-                    if (!menu->reuse_accels && (menu->num_pages > 1)) {
+                    if (!menu->reuse_accels && menu->num_pages > 1) {
                         menu->reuse_accels = TRUE;
                     }
                 } else {


### PR DESCRIPTION
This happens in curses mode in #wizlevelport when a glyph is reused and would select the first occurence of that glyph.