### PR TITLE
Allow empty /oCancellation into BoH

### DIFF
--- a/hackem_changelog.txt
+++ b/hackem_changelog.txt
@@ -15,6 +15,7 @@
 
 Version 1.1 (unreleased)
 
+Fix: Allow wand of cancellation without charges to be put into BoH, this is already allowed for bag of tricks/rats (reported by mobileuser).
 Reflection spell improvements (EvilHack).
 Fix: Infidels should not get any friendly angels on astral plane (reported by mobileuser).
 Fix: Reused glyphs in #wizlevelport in curses mode don't work (menu->reuse_accels does not get set).

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2430,7 +2430,7 @@ register struct obj *obj;
     } else if (obj == current_container) {
         pline("That would be an interesting topological exercise.");
         return 0;
-    } else if ((Is_mbag(obj) || obj->otyp == WAN_CANCELLATION)
+    } else if ((Is_mbag(obj) || (obj->otyp == WAN_CANCELLATION && obj->spe > 0))
              && objects[obj->otyp].oc_name_known 
                && obj->dknown 
                && current_container->otyp == BAG_OF_HOLDING


### PR DESCRIPTION
This is already allowed for bag of tricks/rats if they are uncharged. The bag of tricks/rats implementation checks for amount of charges and allows if there are none even if the player does not know this. Since this information leak is allowed for bag of tricks/rats then this should be fine for wand of cancellation too.
Reported by mobileuser.