### PR TITLE
Message for trying to put gloves over Hand of Vecna

### DIFF
--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -2575,8 +2575,12 @@ boolean noisy;
             *mask = W_ARMF;
     } else if (is_gloves(otmp)) {
         if (uarmg) {
-            if (noisy)
-                already_wearing(c_gloves);
+            if (noisy) {
+                if (uarmg->otyp == MUMMIFIED_HAND)
+                    You_cant("fit %s into a glove.", the(xname(uarmg)));
+                else
+                    already_wearing(c_gloves);
+            }
             err++;
         } else if (welded(uwep)) {
             if (noisy)


### PR DESCRIPTION
When trying to wear gloves over the Hand of Vecna, print a unique message instead of "You are already wearing gloves." (Though it occupies the glove slot, the Hand is not really a pair of gloves.)