### PR TITLE
Fix an incorrect forge crafting recipe

### DIFF
--- a/src/fountain.c
+++ b/src/fountain.c
@@ -556,7 +556,7 @@ static const struct forge_recipe {
     
     /* armor (shields) */
     { SMALL_SHIELD, DAGGER, HELMET, 1, 1 },
-    { ELVEN_SHIELD, SMALL_SHIELD + ELVEN_DAGGER, 1, 1 },
+    { ELVEN_SHIELD, SMALL_SHIELD, ELVEN_DAGGER, 1, 1 },
     { URUK_HAI_SHIELD, ORCISH_SHIELD, ORCISH_SHIELD, 1, 1 },
     { ORCISH_SHIELD, ORCISH_HELM, ORCISH_BOOTS, 1, 1 },
     { LARGE_SHIELD, HELMET, HELMET, 1, 1 },


### PR DESCRIPTION
Adding two object ids together is nonsensical, and this was accidentally specifying only 4 of the 5 fields (leaving the 5th zero initialized).