### PR TITLE
Fix stale perm_invent when toggling option (invweight)

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -4985,6 +4985,8 @@ doset() /* changing options via menu by Per Liboriussen */
         reglyph_darkroom();
         (void) doredraw();
     }
+
+    update_inventory();
     return 0;
 }
 


### PR DESCRIPTION
I added update_inventory() for every change in `O` (options menu).
I only verified the bug with `invweight` which is also how I noticed that the `perm_invent` didn't update the weight in `perm_invent` when toggling the option.