### PR TITLE
Fix cartomancer starting weapon index

### DIFF
--- a/src/u_init.c
+++ b/src/u_init.c
@@ -53,8 +53,8 @@ struct trobj Barbarian[] = {
     { 0, 0, 0, 0, 0 }
 };
 static struct trobj Cartomancer[] = {
-    { HAWAIIAN_SHIRT, 0, ARMOR_CLASS, 1, UNDEF_BLESS },
     { DAGGER, 1, WEAPON_CLASS, 1, UNDEF_BLESS },
+    { HAWAIIAN_SHIRT, 0, ARMOR_CLASS, 1, UNDEF_BLESS },
     { SHURIKEN, 0, GEM_CLASS, 60, UNDEF_BLESS },
     { UNDEF_TYP, UNDEF_SPE, SCROLL_CLASS, 4, UNDEF_BLESS },
     { SCR_CREATE_MONSTER, 0, SCROLL_CLASS, 1, UNDEF_BLESS },


### PR DESCRIPTION
Make the dagger the first in the item array so it gets assigned to index `a` like the starting weapon of all other roles.