### PR TITLE
Adjust Treasury of Proteus behavior

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -385,18 +385,12 @@ boolean resuming;
                     }
 #endif
                     
-                    if (u.ukinghill) {
+                    if (pobj = carrying_arti(ART_TREASURY_OF_PROTEUS)) {
                         if (u.protean > 0)
                             u.protean--;
                         else {
-                            for (pobj = invent; pobj; pobj = pobj->nobj)
-                                if (pobj->oartifact == ART_TREASURY_OF_PROTEUS)
-                                    break;
-                            if (!pobj) 
-                                impossible("Treasury not actually in inventory??");
-                            else if (pobj->cobj) {
+                            if (pobj->cobj)
                                 arti_poly_contents(pobj);
-                            }
                             u.protean = rnz(100) + d(3, 10);
                             update_inventory();
                         }

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -931,7 +931,7 @@ int wtcap;
                 && tech_inuse(T_CHI_HEALING)) {
                 u.uen--;
                 heal++;
-		    }
+            }
             if (heal && !(Withering && heal > 0)) {
                 context.botl = TRUE;
                 u.uhp += heal;

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -102,7 +102,7 @@ static const struct innate {
                  { 0, 0, 0, 0 } },
 
   pir_abil[] = {  { 1, &(HSwimming), "", "" },
-                  { 7, &(HStealth), "stealthy", "" },	/* with cat-like tread ... */
+                  { 7, &(HStealth), "stealthy", "" }, /* with cat-like tread ... */
                   { 11, &(HFast), "quick", "slow" },
                   { 0, 0, 0, 0 } },
 
@@ -500,7 +500,7 @@ boolean parameter; /* So I can't think up of a good name.  So sue me. --KAA */
             else if (parameter)
                 bonchance += otmp->quan;
         }
-	
+
     return sgn((int) bonchance);
 }
 

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -491,7 +491,9 @@ boolean parameter; /* So I can't think up of a good name.  So sue me. --KAA */
 
     for (otmp = invent; otmp; otmp = otmp->nobj)
         if (confers_luck(otmp)) {
-            if (otmp->cursed || wielding_artifact(ART_LUCKLESS_FOLLY))
+            /* Pirates' quest artifact never counts as cursed for them */
+            if (otmp->cursed && !(Role_if(PM_PIRATE) && is_quest_artifact(otmp))
+                || wielding_artifact(ART_LUCKLESS_FOLLY))
                 bonchance -= otmp->quan;
             else if (otmp->blessed)
                 bonchance += otmp->quan;

--- a/src/sit.c
+++ b/src/sit.c
@@ -292,7 +292,7 @@ dosit()
                 verbalize("By thine Imperious order, %s...",
                           flags.female ? "Dame" : "Sire");
                 /* Dungeon wide */
-                do_genocide(5, FALSE);	/* REALLY|ONTHRONE, see do_genocide() */
+                do_genocide(5, FALSE); /* REALLY|ONTHRONE, see do_genocide() */
                 break;
             case 9:
                 /* Magical voice not affected by deafness */
@@ -414,7 +414,7 @@ rndcurse()
         return;
     }
     if ((otmp = carrying_arti(ART_TREASURY_OF_PROTEUS)) && rn2(20)) {
-   	    You(mal_aura, "the cursed treasure chest");
+        You(mal_aura, "the cursed treasure chest");
         /* for non-Pirates, it becomes cursed outright */
         if (otmp->blessed && is_quest_artifact(otmp))
             unbless(otmp);
@@ -488,63 +488,64 @@ rndcurse()
     }
 }
 
+/* curse a few inventory items at random! */
 void
-mrndcurse(mtmp)			/* curse a few inventory items at random! */
+mrndcurse(mtmp)
 register struct monst *mtmp;
 {
-  	int	nobj = 0;
-  	int	cnt, onum;
-  	struct	obj	*otmp;
-  	static const char mal_aura[] = "feel a malignant aura surround %s.";
+    int nobj = 0;
+    int cnt, onum;
+    struct obj *otmp;
+    static const char mal_aura[] = "feel a malignant aura surround %s.";
 
-  	boolean resists = resist(mtmp, 0, 0, FALSE),
+    boolean resists = resist(mtmp, 0, 0, FALSE),
                 vis = couldsee(mtmp->mx, mtmp->my);
     
-  	if (vis && MON_WEP(mtmp) &&
-  	    (MON_WEP(mtmp)->oartifact == ART_MAGICBANE) && rn2(20)) {
-  	    You(mal_aura, "the magic-absorbing staff");
-  	    return;
-  	}
+    if (vis && MON_WEP(mtmp) &&
+        (MON_WEP(mtmp)->oartifact == ART_MAGICBANE) && rn2(20)) {
+        You(mal_aura, "the magic-absorbing staff");
+        return;
+    }
 
-  	if (vis && resists) {
-  	    shieldeff(mtmp->mx, mtmp->my);
-  	    You(mal_aura, mon_nam(mtmp));
-  	}
+    if (vis && resists) {
+        shieldeff(mtmp->mx, mtmp->my);
+        You(mal_aura, mon_nam(mtmp));
+    }
 
-  	for (otmp = mtmp->minvent; otmp; otmp = otmp->nobj) {
-  	    /* gold isn't subject to being cursed or blessed */
-  	    if (otmp->oclass == COIN_CLASS) 
-              continue;
-  	    nobj++;
-  	}
-  	if (nobj) {
-  	    for (cnt = rnd(6/((!!resists) + 1));
-  		      cnt > 0; cnt--)  {
-        		onum = rnd(nobj);
-        		for (otmp = mtmp->minvent; otmp; otmp = otmp->nobj) {
-        		    /* as above */
-        		    if (otmp->oclass == COIN_CLASS) continue;
-        		    if (--onum == 0) break;	/* found the target */
-        		}
-        		/* the !otmp case should never happen; picking an already
-        		   cursed item happens--avoid "resists" message in that case */
-        		if (!otmp || otmp->cursed)
-                continue;	/* next target */
+    for (otmp = mtmp->minvent; otmp; otmp = otmp->nobj) {
+        /* gold isn't subject to being cursed or blessed */
+        if (otmp->oclass == COIN_CLASS) 
+               continue;
+        nobj++;
+    }
+    if (nobj) {
+        for (cnt = rnd(6/((!!resists) + 1));
+             cnt > 0; cnt--)  {
+            onum = rnd(nobj);
+            for (otmp = mtmp->minvent; otmp; otmp = otmp->nobj) {
+                /* as above */
+                if (otmp->oclass == COIN_CLASS) continue;
+                if (--onum == 0) break; /* found the target */
+            }
+            /* the !otmp case should never happen; picking an already
+               cursed item happens--avoid "resists" message in that case */
+            if (!otmp || otmp->cursed)
+                continue; /* next target */
 
-        		if (otmp->oartifact && spec_ability(otmp, SPFX_INTEL) &&
-        		    rn2(10) < 8) {
-                            if (vis)
-                                pline("%s!", Tobjnam(otmp, "resist"));
-        		    continue;
-        		}
+                if (otmp->oartifact && spec_ability(otmp, SPFX_INTEL) &&
+                    rn2(10) < 8) {
+                    if (vis)
+                        pline("%s!", Tobjnam(otmp, "resist"));
+                    continue;
+                }
 
-        		if (otmp->blessed)
-        			  unbless(otmp);
-        		else
-        			  curse(otmp);
-  	    }
-  	    update_inventory();
-  	}
+                if (otmp->blessed)
+                    unbless(otmp);
+                else
+                    curse(otmp);
+        }
+        update_inventory();
+    }
 }
 
 /* remove a random INTRINSIC ability */
@@ -554,8 +555,8 @@ attrcurse()
     switch (rnd(14)) {
     case 1:
         if (HFire_resistance) {
-	    HFire_resistance = HFire_resistance & (TIMEOUT | FROMOUTSIDE | HAVEPARTIAL);
-	    decr_resistance(&HFire_resistance, rnd(50) + 50);
+        HFire_resistance = HFire_resistance & (TIMEOUT | FROMOUTSIDE | HAVEPARTIAL);
+        decr_resistance(&HFire_resistance, rnd(50) + 50);
             You_feel("warmer.");
             break;
         }
@@ -569,8 +570,8 @@ attrcurse()
         /*FALLTHRU*/
     case 3:
         if (HPoison_resistance) {
-	    HPoison_resistance = HPoison_resistance & (TIMEOUT | FROMOUTSIDE | HAVEPARTIAL);
-	    decr_resistance(&HPoison_resistance, rnd(50) + 50);
+        HPoison_resistance = HPoison_resistance & (TIMEOUT | FROMOUTSIDE | HAVEPARTIAL);
+        decr_resistance(&HPoison_resistance, rnd(50) + 50);
             You_feel("a little sick!");
             break;
         }
@@ -586,8 +587,8 @@ attrcurse()
         /*FALLTHRU*/
     case 5:
         if (HCold_resistance) {
-	    HCold_resistance = HCold_resistance & (TIMEOUT | FROMOUTSIDE | HAVEPARTIAL);
-	    decr_resistance(&HCold_resistance, rnd(50) + 50);
+        HCold_resistance = HCold_resistance & (TIMEOUT | FROMOUTSIDE | HAVEPARTIAL);
+        decr_resistance(&HCold_resistance, rnd(50) + 50);
             You_feel("cooler.");
             break;
         }
@@ -640,27 +641,27 @@ attrcurse()
         /*FALLTHRU*/
     case 12:
         if (HSleep_resistance) {
-	    HSleep_resistance = HSleep_resistance & (TIMEOUT | FROMOUTSIDE | HAVEPARTIAL);
-	    decr_resistance(&HSleep_resistance, rnd(50) + 50);
-	    You_feel("a little tired.");
-	    break;
-	}
+        HSleep_resistance = HSleep_resistance & (TIMEOUT | FROMOUTSIDE | HAVEPARTIAL);
+        decr_resistance(&HSleep_resistance, rnd(50) + 50);
+        You_feel("a little tired.");
+        break;
+    }
         /*FALLTHRU*/
     case 13:
         if (HDisint_resistance) {
-	    HDisint_resistance = HDisint_resistance & (TIMEOUT | FROMOUTSIDE | HAVEPARTIAL);
-	    decr_resistance(&HDisint_resistance, rnd(50) + 50);
-	    You_feel("less firm.");
-	    break;
-	}
+        HDisint_resistance = HDisint_resistance & (TIMEOUT | FROMOUTSIDE | HAVEPARTIAL);
+        decr_resistance(&HDisint_resistance, rnd(50) + 50);
+        You_feel("less firm.");
+        break;
+    }
         /*FALLTHRU*/
     case 14:
         if (HShock_resistance) {
-	    HShock_resistance = HShock_resistance & (TIMEOUT | FROMOUTSIDE | HAVEPARTIAL);
-	    decr_resistance(&HShock_resistance, rnd(50) + 50);
-	    You_feel("more conductive.");
-	    break;
-	}
+        HShock_resistance = HShock_resistance & (TIMEOUT | FROMOUTSIDE | HAVEPARTIAL);
+        decr_resistance(&HShock_resistance, rnd(50) + 50);
+        You_feel("more conductive.");
+        break;
+    }
         /*FALLTHRU*/
     default:
         break;

--- a/src/sit.c
+++ b/src/sit.c
@@ -412,15 +412,11 @@ rndcurse()
     if (wielding_artifact(ART_MAGICBANE) && rn2(20)) {
         You(mal_aura, "the magic-absorbing staff");
         return;
-    } else if (u.ukinghill && rn2(20)) {
+    }
+    if ((otmp = carrying_arti(ART_TREASURY_OF_PROTEUS)) && rn2(20)) {
    	    You(mal_aura, "the cursed treasure chest");
-        otmp = 0;
-        for (otmp = invent; otmp; otmp = otmp->nobj)
-            if (otmp->oartifact == ART_TREASURY_OF_PROTEUS)
-                break;
-        if (!otmp) 
-            impossible("Treasury not actually in inventory??");
-        else if (otmp->blessed)
+        /* for non-Pirates, it becomes cursed outright */
+        if (otmp->blessed && is_quest_artifact(otmp))
             unbless(otmp);
         else
             curse(otmp);


### PR DESCRIPTION
Any character carrying the Treasury of Proteus will have it polymorph contents and absorb curses. For Pirates only, even when it's cursed, it affects luck like a noncursed luckstone. For non-Pirates, it becomes cursed outright when it absorbs a curse, even if it was blessed. So Pirates don't need to worry about it becoming cursed, but they have an easier time keeping it blessed if they want to.