### PR TITLE
error in gnoll warrior loadout

### DIFF
--- a/src/makemon.c
+++ b/src/makemon.c
@@ -1710,7 +1710,7 @@ register struct monst *mtmp;
             case PM_GNOLL_WARRIOR:
                 if(!rn2(2)) 
                     (void) mongets(mtmp, ORCISH_HELM);
-                else if (rn2(3))
+                if (rn2(3))
                     (void) mongets(mtmp, SCALE_MAIL);
                 else
                     (void) mongets(mtmp, SPLINT_MAIL);


### PR DESCRIPTION
I know this has basically been abandoned, but this might be worth it: this was a leftover from removing the DSM in gnolls' starting inventory.