### PR TITLE
Don't re-throw windrider if it didn't make it back.

### DIFF
--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -318,6 +318,14 @@ int shotlimit;
                 remove_worn_item(otmp, FALSE);
             oldslot = obj->nobj;
         }
+
+        // If was_thrown flag is set, the item is not in inventory
+        // and thus can't be thrown again. This largely matters
+        // for multishot, returnable projectiles like Windrider.
+        if (otmp->was_thrown) {
+            break;
+        }
+
         freeinv(otmp);
         throwit(otmp, wep_mask, twoweap, oldslot);
     }


### PR DESCRIPTION
# The problem
Boomerangs normally multi-shot the normal way by having a stack of them, but it appears that Windrider aims to be able to do this with only a stack of one if it makes it back to the player. However, if a multi shot check is passed (e.g. `m_shot.n > 1`), then it will try fire twice regardless of whether it makes it back to player inventory or not. If it doesn't, it tries to remove it from player inventory when it is actually on the ground somewhere, leading to the panic.

# Possible Fix
I noticed that `obj::was_thrown` is set IFF the item was recently thrown and it hasn't been picked back up. This seems like an easy check to halt multi shot that doesn't require an inventory LL traversal or passing around extra state from `zap.c:boomhit`. If this an abuse of the `was_thrown` flag, however, it may make sense to do one of the other two options.