### PR TITLE
Fix leak in makemon.c

### DIFF
--- a/src/makemon.c
+++ b/src/makemon.c
@@ -4295,6 +4295,9 @@ int otyp;
             /* otmp was freed via merging with something else */
             otmp = (struct obj *) 0;
         }
+        else {
+            obfree(otmp, (struct obj *) 0);
+        }
         return spe;
     } else
         otmp = (struct obj *) 0; /* obj wasn't able to get created? */


### PR DESCRIPTION
Hi,
I am anew contributor that loves playing this game! So I thought I would also help contribute to this amazing game :)

This PR fixes leak in #505 .
The leak occurs in function `mongets`. Here `otmp` is allocated by `mksobj` but not freed if `mpickobj` fails to free `otmp`.

The patch frees `otmp` in the case that `mpickobj` fails.

Let me know if you found the patch useful or if any modifications are needed!